### PR TITLE
Add AnsiString method on Column class. 

### DIFF
--- a/SharpData/Databases/MySql/MySqlDialect.cs
+++ b/SharpData/Databases/MySql/MySqlDialect.cs
@@ -74,6 +74,7 @@ namespace SharpData.Databases.MySql {
 
     	protected override string GetDbTypeString(DbType type, int precision) {
             switch (type) {
+                case DbType.AnsiString:
                 case DbType.String:
                     if (precision == 0) {
                         return "VARCHAR(255)";

--- a/SharpData/Schema/Column.cs
+++ b/SharpData/Schema/Column.cs
@@ -44,6 +44,7 @@ namespace SharpData.Schema {
             fc.Object.IsAutoIncrement = true;
             return fc; 
         }
+        public static FluentColumn AnsiString(string name, int size = 0) { return new FluentColumn(name, DbType.AnsiString, size); }
         public static FluentColumn String(string name, int size = 0) { return new FluentColumn(name, DbType.String, size); }
         public static FluentColumn Clob(string name, int size = System.Int32.MaxValue) { return new FluentColumn(name, DbType.String, size); }
         public static FluentColumn Binary(string name, int size = System.Int32.MaxValue) { return new FluentColumn(name, DbType.Binary, size); }


### PR DESCRIPTION
Today to add an column with DbType.AnsiString the following we must use the following code:

```c#
Add.Column(new FluentColumn("HashSenha", DbType.AnsiString, 255)).ToTable("Usuarios");
```

With this commits the code will become simpler:

```c#
Add.Column.AnsiString("HashSenha", 255).ToTable("Usuarios");
```

On this pull request I added the DbType.AnsiString support on MySqlDialect using the same case used to implement the DbType.String.