### PR TITLE
Remove some invalid SQL Server types and correct others

### DIFF
--- a/SharpData/Databases/SqlServer/SqlDialect.cs
+++ b/SharpData/Databases/SqlServer/SqlDialect.cs
@@ -158,22 +158,24 @@ namespace SharpData.Databases.SqlServer {
             switch (type) {
                 case DbType.AnsiStringFixedLength:
                     if (precision <= 0) return "CHAR(255)";
-                    if (precision.Between(1, 255)) return String.Format("CHAR({0})", precision);
-                    if (precision.Between(256, 65535)) return "TEXT";
-                    if (precision.Between(65536, 16777215)) return "MEDIUMTEXT";
+                    if (precision.Between(1, 8000)) return String.Format("CHAR({0})", precision);
                     break;
                 case DbType.AnsiString:
                     if (precision <= 0) return "VARCHAR(255)";
-                    if (precision.Between(1, 255)) return String.Format("VARCHAR({0})", precision);
-                    if (precision.Between(256, 65535)) return "TEXT";
-                    if (precision.Between(65536, 16777215)) return "MEDIUMTEXT";
+                    if (precision.Between(1, 8000)) return String.Format("VARCHAR({0})", precision);
+                    if (precision.Between(8001, int.MaxValue)) return "VARCHAR(MAX)";
                     break;
-                case DbType.Binary: return "BINARY";
+                case DbType.Binary:
+                    if (precision <= 0) return "VARBINARY(8000)";
+                    if (precision.Between(1, 8000)) return String.Format("VARBINARY({0}", precision);
+                    if (precision.Between(8001, int.MaxValue)) return "VARBINARY(MAX)";
+                    break;
                 case DbType.Boolean: return "BIT";
-                case DbType.Byte: return "TINYINT UNSIGNED";
+                case DbType.Byte: return "TINYINT";
                 case DbType.Currency: return "MONEY";
-                case DbType.Date: return "DATETIME";
+                case DbType.Date: return "DATE";
                 case DbType.DateTime: return "DATETIME";
+                case DbType.DateTime2: return "DATETIME2";
                 case DbType.Decimal:
                     if (precision <= 0) return "NUMERIC(19,5)";
                     return String.Format("NUMERIC(19,{0})", precision);
@@ -185,15 +187,15 @@ namespace SharpData.Databases.SqlServer {
                 case DbType.Single: return "FLOAT";
                 case DbType.StringFixedLength:
                     if (precision <= 0) return "NCHAR(255)";
-                    if (precision.Between(1, 8000)) return String.Format("NCHAR({0})", precision);
-                    return "TEXT";
+                    if (precision.Between(1, 4000)) return String.Format("NCHAR({0})", precision);
+                    break;
                 case DbType.String:
                     if (precision <= 0) return "NVARCHAR(255)";
-                    if (precision.Between(1, 8000)) return String.Format("NVARCHAR({0})", precision);
-                    return "TEXT";
+                    if (precision.Between(1, 4000)) return String.Format("NVARCHAR({0})", precision);
+                    return "NVARCHAR(MAX)";
                 case DbType.Time: return "TIME";
             }
-            throw new DataTypeNotAvailableException(String.Format("The type {0} is no available for sqlserver", type));
+            throw new DataTypeNotAvailableException(String.Format("The type {0} with precision {1} is no available for sqlserver", type, precision));
         }
 
         public override string GetColumnValueToSql(object value) {


### PR DESCRIPTION
Some types returned on SQLServer dialect did not exist and others could be optimized, but will be only compatible with SQL Server 2008 or newer.

The biggest difference are:

- DbType.Binary that now returns VARBINARY instead of BINARY, 
- DbType.AnsiString that now returns VARCHAR(MAX) for precision greater than 8000
- DbType.AnsiStringFixedLength that now returns CHAR, but only for precision between 0 and 8000
- DbType.Date that now returns DATE
- DbType.DateTime2 has been added
- DbType.String that now returns NVARCHAR(MAX) for precision greater than 4000
- DbType.StringFixedLenght that now return NCHAR, but only for precision between 0 and 4000

For types that are not supported the error message explains that it could be because of type and precision.
